### PR TITLE
Update setup data

### DIFF
--- a/scripts/FileTools.hx
+++ b/scripts/FileTools.hx
@@ -33,6 +33,7 @@ class FileTools {
 
 				if (FileSystem.isDirectory(path + name)) {
 					deleteDir(path + name);
+					sys.FileSystem.deleteDirectory(path + name);
 				} else {
 					FileSystem.deleteFile(path + name);
 				}

--- a/scripts/SetupData.hx
+++ b/scripts/SetupData.hx
@@ -52,5 +52,6 @@ class SetupData {
 				FileTools.copyDir('OneLifeGameSourceData/$path', 'OneLifeData7/$path');
 			}
 		}
+		FileTools.deleteDir("OneLifeGameSourceData");
 	}
 }


### PR DESCRIPTION
1. OneLifeGameSourceData appears to only be used for initial setup by the setup data script, as it's relatively large, let's not keep it in the working directory longer than necessary.
2. Following this, I discovered an issue in FileTools' deleteDir() function, which only deletes the contents of the directory and never any of the actual directories, contrary to how it is named.